### PR TITLE
Handle null values returned from `getCTM`

### DIFF
--- a/src/svg-to-paths.ts
+++ b/src/svg-to-paths.ts
@@ -96,8 +96,14 @@ export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Lin
   for (const path of walkSvgShapes(svg)) {
     const type = path.nodeName.toLowerCase()
     const ctm = (path as SVGGraphicsElement).getCTM()
-    const xf = ([x,y]: [number, number]): Point => { svgPoint.x = x; svgPoint.y = y;
-      const xfd = svgPoint.matrixTransform(ctm); return [xfd.x, xfd.y] }
+    const xf = ctm == null
+      ? ([x,y]: [number, number]): Point => { return [x, y]; }
+      : ([x,y]: [number, number]): Point => {
+          svgPoint.x = x;
+          svgPoint.y = y;
+          const xfd = svgPoint.matrixTransform(ctm);
+          return [xfd.x, xfd.y]
+        };
     const pathData = getPathData(path, {normalize: true})
     let cur: Point = null
     let closePoint = null


### PR DESCRIPTION
According the the [SVG standard][] the `getCTM` method may return `null`. This is *supposed* to only happen when the SVG element is not attached to a document, however I'm observing that it can be returned even when the SVG is attached to the document in Firefox. To hack around this scenario, we simply use un-transformed points when given a `null` CTM, which seems to work correctly.

[SVG standard]: https://www.w3.org/TR/SVG/types.html#__svg__SVGGraphicsElement__getCTM