### PR TITLE
Enable TypeScript strict mode + fix up issues

### DIFF
--- a/src/svg-to-paths.ts
+++ b/src/svg-to-paths.ts
@@ -91,28 +91,28 @@ interface Line {
   groupId?: string;
 }
 
-function getStroke(shape: SVGElement): string | null {
-  if (!shape) return null
+function getStroke(shape: SVGElement): string | undefined {
+  if (!shape) return undefined
   const explicitStroke = shape.getAttribute('stroke') || shape.style.stroke
   if (explicitStroke) {
     return explicitStroke
   }
-  if (shape === shape.ownerSVGElement || !shape.ownerSVGElement) return null
+  if (shape === shape.ownerSVGElement || !shape.ownerSVGElement) return undefined
   if (shape.parentNode) {
     return getStroke(shape.parentNode as SVGElement)
   }
-  return null
+  return undefined
 }
 
-function getGroupId(shape: SVGElement): string | null {
-  if (!shape) return null
+function getGroupId(shape: SVGElement): string | undefined {
+  if (!shape) return undefined
   if (shape.id && shape.nodeName.toLowerCase() === 'g') {
     return shape.id
   }
   if (shape.parentNode) {
     return getGroupId(shape.parentNode as SVGElement)
   }
-  return null
+  return undefined
 }
 
 function point(x: number, y: number): Point {
@@ -154,8 +154,8 @@ export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Lin
         closePoint = cur
         paths.push({
           points: [cur],
-          stroke: getStroke(shape) ?? undefined,
-          groupId: getGroupId(shape) ?? undefined
+          stroke: getStroke(shape),
+          groupId: getGroupId(shape),
         });
       } else if (cmd.type === 'L') {
         cur = xf(cmd.values)

--- a/src/svg-to-paths.ts
+++ b/src/svg-to-paths.ts
@@ -175,11 +175,8 @@ export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Lin
         }
         cur = point(tx3, ty3)
       } else if (cmd.type === 'A') {
-        const [rx_, ry_, xAxisRotation, largeArc, sweep, x, y] = cmd.values
-        const phi = xAxisRotation
-        const fS = sweep
-        const fA = largeArc
-        const {cos, sin, atan2, sqrt, sign, acos, abs, ceil} = Math
+        const [rx_, ry_, phi, fA, fS, x, y] = cmd.values
+        const {cos, sin, sqrt, acos, abs, ceil} = Math
         if (cur === null) {
           throw new Error(`A ${cmd.values} encountered without current point`)
         }
@@ -228,8 +225,7 @@ export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Lin
 
         // https://i.imgur.com/JORhNjU.jpg
         // maximum error based on maximum deviation from true arc
-        const e0 = maxError
-        const n = ceil(abs(dt) / acos(1-e0/rx))
+        const n = ceil(abs(dt) / acos(1-maxError/rx))
 
         for (let i = 1; i <= n; i++) {
           const theta = t1 + dt * i/n

--- a/src/svg-to-paths.ts
+++ b/src/svg-to-paths.ts
@@ -122,6 +122,15 @@ function point(x: number, y: number): Point {
   return pt as Point
 }
 
+function ang(ux: number, uy: number, vx: number, vy: number) {
+  /*
+  (ux*vy - uy*vx < 0 ? -1 : 1) *
+    acos((ux*vx+uy*vy) / sqrt(ux*ux+uy*uy)*sqrt(vx*vx+vy*vy))
+    */
+  // https://github.com/paperjs/paper.js/blob/f5366fb3cb53bc1ea52e9792e2ec2584c0c4f9c1/src/path/Path.js#L2516
+  return Math.atan2(ux * vy - uy * vx, ux * vx + uy * vy)
+}
+
 export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Line[] {
   const {maxError = 0.1} = options;
   const svgPoint = (svg as any).createSVGPoint()
@@ -196,14 +205,7 @@ export function flattenSVG(svg: SVGElement, options: Partial<Options> = {}): Lin
               cy_ = k * -ry * x1_ / rx
         const cx = cos(phi) * cx_ - sin(phi) * cy_ + (cur[0] + x)/2,
               cy = sin(phi) * cx_ + cos(phi) * cy_ + (cur[1] + y)/2
-        const ang = (ux: number, uy: number, vx: number, vy: number) => {
-          /*
-          (ux*vy - uy*vx < 0 ? -1 : 1) *
-            acos((ux*vx+uy*vy) / sqrt(ux*ux+uy*uy)*sqrt(vx*vx+vy*vy))
-            */
-          // https://github.com/paperjs/paper.js/blob/f5366fb3cb53bc1ea52e9792e2ec2584c0c4f9c1/src/path/Path.js#L2516
-          return atan2(ux * vy - uy * vx, ux*vx + uy*vy)
-        }
+
         const t1 = ang(1, 0, (x1_-cx_)/rx, (y1_-cy_)/ry)
         const dt_ = ang((x1_-cx_)/rx, (y1_-cy_)/ry, (-x1_-cx_)/rx,
           (-y1_-cy_)/ry) % (Math.PI*2)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
+    "strict": true,
     "paths": {
       "*": [
         "node_modules/*"


### PR DESCRIPTION
Originally from #14.

This PR:

* enables `strict` and fixes up some problems uncovered by it
* moves the `ang()` inner function to a free function
* fixes up some unnecessary variable reassignment/aliasing